### PR TITLE
ftp.c: Fix num_to_month

### DIFF
--- a/ftp.c
+++ b/ftp.c
@@ -160,8 +160,7 @@ static void client_close_data_connection(ClientInfo *client)
 static int gen_list_format(char *out, int n, int dir, unsigned int file_size,
 	int month_n, int day_n, int hour, int minute, const char *filename)
 {
-	/* Temporary static const workaround */
-	char *num_to_month[] = {
+	static const char num_to_month[][4] = {
 		"Jan", "Feb", "Mar", "Apr", "May", "Jun",
 		"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
 	};


### PR DESCRIPTION
Your first version was an array of non-const pointers. It means it costs 4 \* 12 = 48 bytes in .rodata and 4 \* 12 = 48 bytes in .data, total 96 bytes.
The second one is not static and strings are not const, so it will cost 48 bytes in .data and 48 bytes in stack, and it needs code to build the array, so total is more than 96 bytes.

My commit solves the problem. It only cost 48 bytes in .rodata.

The first one may have caused a problem with psp2-fixup because pointers in .data refers to .rodata. I'll fix it as soon as possible.
