### PR TITLE
Add support for custom command dispatchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Ignore build files.
+*.a
 *.o
 *.elf
 *.velf

--- a/libftpvita/ftpvita.c
+++ b/libftpvita/ftpvita.c
@@ -38,42 +38,6 @@
  *     /cache0:/foo/bar
  */
 
-typedef enum {
-	FTP_DATA_CONNECTION_NONE,
-	FTP_DATA_CONNECTION_ACTIVE,
-	FTP_DATA_CONNECTION_PASSIVE,
-} DataConnectionType;
-
-typedef struct ClientInfo {
-	/* Client number */
-	int num;
-	/* Thread UID */
-	SceUID thid;
-	/* Control connection socket FD */
-	int ctrl_sockfd;
-	/* Data connection attributes */
-	int data_sockfd;
-	DataConnectionType data_con_type;
-	SceNetSockaddrIn data_sockaddr;
-	/* PASV mode client socket */
-	SceNetSockaddrIn pasv_sockaddr;
-	int pasv_sockfd;
-	/* Remote client net info */
-	SceNetSockaddrIn addr;
-	/* Receive buffer attributes */
-	int n_recv;
-	char recv_buffer[512];
-	/* Current working directory */
-	char cur_path[PATH_MAX];
-	/* Rename path */
-	char rename_path[PATH_MAX];
-	/* Client list */
-	struct ClientInfo *next;
-	struct ClientInfo *prev;
-	/* Offset for transfer resume */
-	unsigned int restore_point;
-} ClientInfo;
-
 typedef struct {
 	const char *cmd;
 	cmd_dispatch_func func;
@@ -97,7 +61,7 @@ static SceNetInAddr vita_addr;
 static SceUID server_thid;
 static int server_sockfd;
 static int number_clients = 0;
-static ClientInfo *client_list = NULL;
+static ftpvita_client_info_t *client_list = NULL;
 static SceUID client_list_mtx;
 
 static int netctl_init = -1;
@@ -124,7 +88,7 @@ static void log_func(ftpvita_log_cb_t log_cb, const char *s, ...)
 #define client_send_ctrl_msg(cl, str) \
 	sceNetSend(cl->ctrl_sockfd, str, strlen(str), 0)
 
-static inline void client_send_data_msg(ClientInfo *client, const char *str)
+static inline void client_send_data_msg(ftpvita_client_info_t *client, const char *str)
 {
 	if (client->data_con_type == FTP_DATA_CONNECTION_ACTIVE) {
 		sceNetSend(client->data_sockfd, str, strlen(str), 0);
@@ -133,7 +97,7 @@ static inline void client_send_data_msg(ClientInfo *client, const char *str)
 	}
 }
 
-static inline int client_recv_data_raw(ClientInfo *client, void *buf, unsigned int len)
+static inline int client_recv_data_raw(ftpvita_client_info_t *client, void *buf, unsigned int len)
 {
 	if (client->data_con_type == FTP_DATA_CONNECTION_ACTIVE) {
 		return sceNetRecv(client->data_sockfd, buf, len, 0);
@@ -142,7 +106,7 @@ static inline int client_recv_data_raw(ClientInfo *client, void *buf, unsigned i
 	}
 }
 
-static inline void client_send_data_raw(ClientInfo *client, const void *buf, unsigned int len)
+static inline void client_send_data_raw(ftpvita_client_info_t *client, const void *buf, unsigned int len)
 {
 	if (client->data_con_type == FTP_DATA_CONNECTION_ACTIVE) {
 		sceNetSend(client->data_sockfd, buf, len, 0);
@@ -160,32 +124,32 @@ static inline const char *get_vita_path(const char *path)
 		return NULL;
 }
 
-static void cmd_NOOP_func(ClientInfo *client)
+static void cmd_NOOP_func(ftpvita_client_info_t *client)
 {
 	client_send_ctrl_msg(client, "200 No operation ;)\n");
 }
 
-static void cmd_USER_func(ClientInfo *client)
+static void cmd_USER_func(ftpvita_client_info_t *client)
 {
 	client_send_ctrl_msg(client, "331 Username OK, need password b0ss.\n");
 }
 
-static void cmd_PASS_func(ClientInfo *client)
+static void cmd_PASS_func(ftpvita_client_info_t *client)
 {
 	client_send_ctrl_msg(client, "230 User logged in!\n");
 }
 
-static void cmd_QUIT_func(ClientInfo *client)
+static void cmd_QUIT_func(ftpvita_client_info_t *client)
 {
 	client_send_ctrl_msg(client, "221 Goodbye senpai :'(\n");
 }
 
-static void cmd_SYST_func(ClientInfo *client)
+static void cmd_SYST_func(ftpvita_client_info_t *client)
 {
 	client_send_ctrl_msg(client, "215 UNIX Type: L8\n");
 }
 
-static void cmd_PASV_func(ClientInfo *client)
+static void cmd_PASV_func(ftpvita_client_info_t *client)
 {
 	int ret;
 	UNUSED(ret);
@@ -245,7 +209,7 @@ static void cmd_PASV_func(ClientInfo *client)
 	client->data_con_type = FTP_DATA_CONNECTION_PASSIVE;
 }
 
-static void cmd_PORT_func(ClientInfo *client)
+static void cmd_PORT_func(ftpvita_client_info_t *client)
 {
 	unsigned int data_ip[4];
 	unsigned int porthi, portlo;
@@ -294,7 +258,7 @@ static void cmd_PORT_func(ClientInfo *client)
 	client_send_ctrl_msg(client, "200 PORT command successful!\n");
 }
 
-static void client_open_data_connection(ClientInfo *client)
+static void client_open_data_connection(ftpvita_client_info_t *client)
 {
 	int ret;
 	UNUSED(ret);
@@ -318,7 +282,7 @@ static void client_open_data_connection(ClientInfo *client)
 	}
 }
 
-static void client_close_data_connection(ClientInfo *client)
+static void client_close_data_connection(ftpvita_client_info_t *client)
 {
 	sceNetSocketClose(client->data_sockfd);
 	/* In passive mode we have to close the client pasv socket too */
@@ -348,7 +312,7 @@ static int gen_list_format(char *out, int n, int dir, unsigned int file_size,
 		filename);
 }
 
-static void send_LIST(ClientInfo *client, const char *path)
+static void send_LIST(ftpvita_client_info_t *client, const char *path)
 {
 	int i;
 	char buffer[512];
@@ -420,7 +384,7 @@ static void send_LIST(ClientInfo *client, const char *path)
 	client_send_ctrl_msg(client, "226 Transfer complete.\n");
 }
 
-static void cmd_LIST_func(ClientInfo *client)
+static void cmd_LIST_func(ftpvita_client_info_t *client)
 {
 	char list_path[PATH_MAX];
 
@@ -433,7 +397,7 @@ static void cmd_LIST_func(ClientInfo *client)
 	}
 }
 
-static void cmd_PWD_func(ClientInfo *client)
+static void cmd_PWD_func(ftpvita_client_info_t *client)
 {
 	char msg[PATH_MAX];
 	sprintf(msg, "257 \"%s\" is the current directory.\n", client->cur_path);
@@ -465,7 +429,7 @@ static void dir_up(char *path)
 	}
 }
 
-static void cmd_CWD_func(ClientInfo *client)
+static void cmd_CWD_func(ftpvita_client_info_t *client)
 {
 	char cmd_path[PATH_MAX];
 	char tmp_path[PATH_MAX];
@@ -511,7 +475,7 @@ static void cmd_CWD_func(ClientInfo *client)
 	}
 }
 
-static void cmd_TYPE_func(ClientInfo *client)
+static void cmd_TYPE_func(ftpvita_client_info_t *client)
 {
 	char data_type;
 	char format_control[8];
@@ -534,13 +498,13 @@ static void cmd_TYPE_func(ClientInfo *client)
 	}
 }
 
-static void cmd_CDUP_func(ClientInfo *client)
+static void cmd_CDUP_func(ftpvita_client_info_t *client)
 {
 	dir_up(client->cur_path);
 	client_send_ctrl_msg(client, "200 Command okay.\n");
 }
 
-static void send_file(ClientInfo *client, const char *path)
+static void send_file(ftpvita_client_info_t *client, const char *path)
 {
 	unsigned char *buffer;
 	SceUID fd;
@@ -578,7 +542,7 @@ static void send_file(ClientInfo *client, const char *path)
 
 /* This function generates an FTP valid path with the input path
  * from RETR, STOR, DELE, RMD, MKD, RNFR and RNTO commands */
-static void gen_filepath(ClientInfo *client, char *dest_path)
+static void gen_filepath(ftpvita_client_info_t *client, char *dest_path)
 {
 	char cmd_path[PATH_MAX];
 	sscanf(client->recv_buffer, "%*[^ ] %[^\r\n\t]", cmd_path);
@@ -593,14 +557,14 @@ static void gen_filepath(ClientInfo *client, char *dest_path)
 	}
 }
 
-static void cmd_RETR_func(ClientInfo *client)
+static void cmd_RETR_func(ftpvita_client_info_t *client)
 {
 	char dest_path[PATH_MAX];
 	gen_filepath(client, dest_path);
 	send_file(client, get_vita_path(dest_path));
 }
 
-static void receive_file(ClientInfo *client, const char *path)
+static void receive_file(ftpvita_client_info_t *client, const char *path)
 {
 	unsigned char *buffer;
 	SceUID fd;
@@ -649,14 +613,14 @@ static void receive_file(ClientInfo *client, const char *path)
 	}
 }
 
-static void cmd_STOR_func(ClientInfo *client)
+static void cmd_STOR_func(ftpvita_client_info_t *client)
 {
 	char dest_path[PATH_MAX];
 	gen_filepath(client, dest_path);
 	receive_file(client, get_vita_path(dest_path));
 }
 
-static void delete_file(ClientInfo *client, const char *path)
+static void delete_file(ftpvita_client_info_t *client, const char *path)
 {
 	DEBUG("Deleting: %s\n", path);
 
@@ -667,14 +631,14 @@ static void delete_file(ClientInfo *client, const char *path)
 	}
 }
 
-static void cmd_DELE_func(ClientInfo *client)
+static void cmd_DELE_func(ftpvita_client_info_t *client)
 {
 	char dest_path[PATH_MAX];
 	gen_filepath(client, dest_path);
 	delete_file(client, get_vita_path(dest_path));
 }
 
-static void delete_dir(ClientInfo *client, const char *path)
+static void delete_dir(ftpvita_client_info_t *client, const char *path)
 {
 	int ret;
 	DEBUG("Deleting: %s\n", path);
@@ -688,14 +652,14 @@ static void delete_dir(ClientInfo *client, const char *path)
 	}
 }
 
-static void cmd_RMD_func(ClientInfo *client)
+static void cmd_RMD_func(ftpvita_client_info_t *client)
 {
 	char dest_path[PATH_MAX];
 	gen_filepath(client, dest_path);
 	delete_dir(client, get_vita_path(dest_path));
 }
 
-static void create_dir(ClientInfo *client, const char *path)
+static void create_dir(ftpvita_client_info_t *client, const char *path)
 {
 	DEBUG("Creating: %s\n", path);
 
@@ -706,7 +670,7 @@ static void create_dir(ClientInfo *client, const char *path)
 	}
 }
 
-static void cmd_MKD_func(ClientInfo *client)
+static void cmd_MKD_func(ftpvita_client_info_t *client)
 {
 	char dest_path[PATH_MAX];
 	gen_filepath(client, dest_path);
@@ -719,7 +683,7 @@ static int file_exists(const char *path)
 	return (sceIoGetstat(path, &stat) >= 0);
 }
 
-static void cmd_RNFR_func(ClientInfo *client)
+static void cmd_RNFR_func(ftpvita_client_info_t *client)
 {
 	char path_src[PATH_MAX];
 	const char *vita_path_src;
@@ -737,7 +701,7 @@ static void cmd_RNFR_func(ClientInfo *client)
 	client_send_ctrl_msg(client, "250 I need the destination name b0ss.\n");
 }
 
-static void cmd_RNTO_func(ClientInfo *client)
+static void cmd_RNTO_func(ftpvita_client_info_t *client)
 {
 	char path_dst[PATH_MAX];
 	const char *vita_path_dst;
@@ -754,7 +718,7 @@ static void cmd_RNTO_func(ClientInfo *client)
 	client_send_ctrl_msg(client, "226 Rename completed.\n");
 }
 
-static void cmd_SIZE_func(ClientInfo *client)
+static void cmd_SIZE_func(ftpvita_client_info_t *client)
 {
 	SceIoStat stat;
 	char path[PATH_MAX];
@@ -772,7 +736,7 @@ static void cmd_SIZE_func(ClientInfo *client)
 	client_send_ctrl_msg(client, cmd);
 }
 
-static void cmd_REST_func(ClientInfo *client)
+static void cmd_REST_func(ftpvita_client_info_t *client)
 {	
 	char cmd[64];
 	sscanf(client->recv_buffer, "%*[^ ] %d", &client->restore_point);
@@ -780,7 +744,7 @@ static void cmd_REST_func(ClientInfo *client)
 	client_send_ctrl_msg(client, cmd);
 }
 
-static void cmd_FEAT_func(ClientInfo *client)
+static void cmd_FEAT_func(ftpvita_client_info_t *client)
 {	
 	/*So client would know that we support resume */
 	client_send_ctrl_msg(client, "211-extensions\n");
@@ -788,7 +752,7 @@ static void cmd_FEAT_func(ClientInfo *client)
 	client_send_ctrl_msg(client, "211 end\n");
 }
 
-static void cmd_APPE_func(ClientInfo *client)
+static void cmd_APPE_func(ftpvita_client_info_t *client)
 {	
 	/* set restore point to not 0
 	restore point numeric value only matters if we RETR file from vita.
@@ -847,7 +811,7 @@ static cmd_dispatch_func get_dispatch_func(const char *cmd)
 	return NULL;
 }
 
-static void client_list_add(ClientInfo *client)
+static void client_list_add(ftpvita_client_info_t *client)
 {
 	/* Add the client at the front of the client list */
 	sceKernelLockMutex(client_list_mtx, 1, NULL);
@@ -868,7 +832,7 @@ static void client_list_add(ClientInfo *client)
 	sceKernelUnlockMutex(client_list_mtx, 1);
 }
 
-static void client_list_delete(ClientInfo *client)
+static void client_list_delete(ftpvita_client_info_t *client)
 {
 	/* Remove the client from the client list */
 	sceKernelLockMutex(client_list_mtx, 1, NULL);
@@ -890,7 +854,7 @@ static void client_list_delete(ClientInfo *client)
 
 static void client_list_thread_end()
 {
-	ClientInfo *it, *next;
+	ftpvita_client_info_t *it, *next;
 	SceUID client_thid;
 	const int data_abort_flags = SCE_NET_SOCKET_ABORT_FLAG_RCV_PRESERVATION |
 				SCE_NET_SOCKET_ABORT_FLAG_SND_PRESERVATION;
@@ -930,7 +894,7 @@ static int client_thread(SceSize args, void *argp)
 {
 	char cmd[16];
 	cmd_dispatch_func dispatch_func;
-	ClientInfo *client = *(ClientInfo **)argp;
+	ftpvita_client_info_t *client = *(ftpvita_client_info_t **)argp;
 
 	DEBUG("Client thread %i started!\n", client->num);
 
@@ -1058,8 +1022,8 @@ static int server_thread(SceSize args, void *argp)
 
 			DEBUG("Client %i thread UID: 0x%08X\n", number_clients, client_thid);
 
-			/* Allocate the ClientInfo struct for the new client */
-			ClientInfo *client = malloc(sizeof(*client));
+			/* Allocate the ftpvita_client_info_t struct for the new client */
+			ftpvita_client_info_t *client = malloc(sizeof(*client));
 			client->num = number_clients;
 			client->thid = client_thid;
 			client->ctrl_sockfd = client_sockfd;
@@ -1289,8 +1253,12 @@ int ftpvita_ext_del_custom_command(const char *cmd)
 	return 0;
 }
 
-void ftpvita_ext_client_send_ctrl_msg(ClientInfo *client, const char *msg)
+void ftpvita_ext_client_send_ctrl_msg(ftpvita_client_info_t *client, const char *msg)
 {
 	client_send_ctrl_msg(client, msg);
 }
 
+void ftpvita_ext_client_send_data_msg(ftpvita_client_info_t *client, const char *str)
+{
+	client_send_data_msg(client, str);
+}

--- a/libftpvita/ftpvita.h
+++ b/libftpvita/ftpvita.h
@@ -21,11 +21,48 @@ void ftpvita_set_file_buf_size(unsigned int size);
 
 /* Extended functionality */
 
-typedef struct ClientInfo ClientInfo; // Opaque
-typedef void (*cmd_dispatch_func)(ClientInfo *client); // Command handler
+typedef enum {
+	FTP_DATA_CONNECTION_NONE,
+	FTP_DATA_CONNECTION_ACTIVE,
+	FTP_DATA_CONNECTION_PASSIVE,
+} DataConnectionType;
+
+typedef struct ftpvita_client_info {
+	/* Client number */
+	int num;
+	/* Thread UID */
+	SceUID thid;
+	/* Control connection socket FD */
+	int ctrl_sockfd;
+	/* Data connection attributes */
+	int data_sockfd;
+	DataConnectionType data_con_type;
+	SceNetSockaddrIn data_sockaddr;
+	/* PASV mode client socket */
+	SceNetSockaddrIn pasv_sockaddr;
+	int pasv_sockfd;
+	/* Remote client net info */
+	SceNetSockaddrIn addr;
+	/* Receive buffer attributes */
+	int n_recv;
+	char recv_buffer[512];
+	/* Current working directory */
+	char cur_path[PATH_MAX];
+	/* Rename path */
+	char rename_path[PATH_MAX];
+	/* Client list */
+	struct ftpvita_client_info *next;
+	struct ftpvita_client_info *prev;
+	/* Offset for transfer resume */
+	unsigned int restore_point;
+} ftpvita_client_info_t;
+
+
+typedef void (*cmd_dispatch_func)(ftpvita_client_info_t *client); // Command handler
 
 int ftpvita_ext_add_custom_command(const char *cmd, cmd_dispatch_func func);
 int ftpvita_ext_del_custom_command(const char *cmd);
-void ftpvita_ext_client_send_ctrl_msg(ClientInfo *client, const char *msg);
+void ftpvita_ext_client_send_ctrl_msg(ftpvita_client_info_t *client, const char *msg);
+void ftpvita_ext_client_send_data_msg(ftpvita_client_info_t *client, const char *str);
 
 #endif

--- a/libftpvita/ftpvita.h
+++ b/libftpvita/ftpvita.h
@@ -19,5 +19,13 @@ void ftpvita_set_info_log_cb(ftpvita_log_cb_t cb);
 void ftpvita_set_debug_log_cb(ftpvita_log_cb_t cb);
 void ftpvita_set_file_buf_size(unsigned int size);
 
+/* Extended functionality */
+
+typedef struct ClientInfo ClientInfo; // Opaque
+typedef void (*cmd_dispatch_func)(ClientInfo *client); // Command handler
+
+int ftpvita_ext_add_custom_command(const char *cmd, cmd_dispatch_func func);
+int ftpvita_ext_del_custom_command(const char *cmd);
+void ftpvita_ext_client_send_ctrl_msg(ClientInfo *client, const char *msg);
 
 #endif


### PR DESCRIPTION
I have added support for hooking custom commands. The idea here is that people using libftpvita can support custom commands in their code, allowing some kind of new applications.

I have created a psvita organizer to be able to upload vita applications directly from the computer:
https://github.com/soywiz/vitaorganizer

And my current objective is to be able to support this:
https://github.com/TheOfficialFloW/VitaShell/issues/38

After uploading be able to signal VitaShell, so it can start promoting the just uploaded app in just one step.

So a the idea is to create a command like "PROM":
And then with ftpvita_ext_add_custom_command, being able to execute code related to promoting apps.

But another idea could be to create a command like "TREESIZE" to be able to get the size of a directory tree directly, for example to get the size of a game faster.
