### PR TITLE
Fix headers

### DIFF
--- a/libftpvita/ftpvita.c
+++ b/libftpvita/ftpvita.c
@@ -2,6 +2,8 @@
  * Copyright (c) 2015-2016 Sergi Granell (xerpi)
  */
 
+#include "ftpvita.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -15,8 +17,6 @@
 
 #include <psp2/net/net.h>
 #include <psp2/net/netctl.h>
-
-#include "ftpvita.h"
 
 #define UNUSED(x) (void)(x)
 

--- a/libftpvita/ftpvita.h
+++ b/libftpvita/ftpvita.h
@@ -6,6 +6,9 @@
 #define FTPVITA_H
 
 #include <psp2/types.h>
+#include <sys/syslimits.h>
+#include <psp2/net/net.h>
+#include <psp2/net/netctl.h>
 
 typedef void (*ftpvita_log_cb_t)(const char *);
 


### PR DESCRIPTION
After the custom commands, the libftpvita.h header was broken outside the project, so not being able to compile Vitashell.
I have moved the `#include` to the top, so we can know if it works just compiling libftpvita.
